### PR TITLE
build: Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @edx/community-engineering


### PR DESCRIPTION
We no longer want this CODEOWNERS file - the community-engineering team no longer exists.