### PR TITLE
build: remove superfluous check for lockfile changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
         node-version: ${{ matrix.node }}
     - name: Install dependencies
       run: npm ci
-    - name: Validate package-lock.json changes
-      run: make validate-no-uncommitted-package-lock-changes
     - name: Lint
       run: npm run lint
     - name: Test

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,3 @@ push_translations:
 # Pulls translations from Transifex.
 pull_translations:
 	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
-
-# This target is used by Travis.
-validate-no-uncommitted-package-lock-changes:
-	# Checking for package-lock.json changes...
-	git diff --exit-code package-lock.json


### PR DESCRIPTION
`npm ci` never produces lockfile changes so it makes no sense to check for such changes here. Including this serves only to confuse people about how node dependency management works.