### PR TITLE
fix: ensure ExamplePage renders without JS error

### DIFF
--- a/src/example/ExamplePage.jsx
+++ b/src/example/ExamplePage.jsx
@@ -1,10 +1,12 @@
-const ExamplePage = () => {
+import { Container } from '@edx/paragon';
+
+const ExamplePage = () => (
   <main>
-    <div className="container-fluid">
+    <Container className="py-5">
       <h1>Example Page</h1>
       <p>Hello world!</p>
-    </div>
-  </main>;
-};
+    </Container>
+  </main>
+);
 
 export default ExamplePage;


### PR DESCRIPTION
Running the example app immediately throws a JS error due to nothing being returned by the `ExamplePage` component:

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/2828721/215769896-31eb63e7-a8ef-4ad6-a9d3-e3c7577bba8d.png">

This PR fixes it:

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/2828721/215770492-67173648-602b-42b4-bdd6-a1db786f57d4.png">
