### PR TITLE
feat: use `atlas` in `make pull_translations`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 export TRANSIFEX_RESOURCE = frontend-template-application
 transifex_langs = "ar,fr,es_419,zh_CN"
 
+intl_imports = ./node_modules/.bin/intl-imports.js
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
@@ -42,6 +43,20 @@ push_translations:
 	# Pushing comments to Transifex...
 	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
 
+ifeq ($(OPENEDX_ATLAS_PULL),)
 # Pulls translations from Transifex.
 pull_translations:
 	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
+else
+# Pulls translations using atlas.
+pull_translations:
+	rm -rf src/i18n/messages
+	mkdir src/i18n/messages
+	cd src/i18n/messages \
+	   && atlas pull --filter=$(transifex_langs) \
+	            translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
+	            translations/frontend-component-header/src/i18n/messages:frontend-component-header \
+	            translations/frontend-template-application/src/i18n/messages:frontend-template-application
+
+	$(intl_imports) frontend-component-header frontend-component-footer frontend-template-application
+endif

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
-        "@edx/frontend-component-footer": "11.7.2",
-        "@edx/frontend-component-header": "3.6.5",
-        "@edx/frontend-platform": "3.3.1",
+        "@edx/frontend-component-footer": "11.7.3",
+        "@edx/frontend-component-header": "3.7.3",
+        "@edx/frontend-platform": "4.1.0",
         "@edx/paragon": "^20.20.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
@@ -3070,11 +3070,11 @@
       }
     },
     "node_modules/@edx/frontend-component-footer": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.2.tgz",
-      "integrity": "sha512-joyygHAE8kuG50FIjiY8obEG0ARVAVRrJXOiOCHWGfu2Mie02/Rv0lFpwTdeBC0AHS6rnegXSdzhjuVgigyx1A==",
+      "version": "11.7.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.3.tgz",
+      "integrity": "sha512-CSLofrLoCglJTSk9SxdTAF/5nqjlJDcisgzSFj57+ecMcbqCUyZlE7yFxKly3NGMnNw+lXIYr9hps7gpOQMnHg==",
       "dependencies": {
-        "@edx/frontend-platform": "^4.0.1",
+        "@edx/frontend-platform": "^4.1.0",
         "@fortawesome/fontawesome-svg-core": "6.4.0",
         "@fortawesome/free-brands-svg-icons": "6.4.0",
         "@fortawesome/free-regular-svg-icons": "6.4.0",
@@ -3085,45 +3085,6 @@
         "prop-types": "^15.5.10",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@edx/frontend-component-footer/node_modules/@edx/frontend-platform": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.1.0.tgz",
-      "integrity": "sha512-7RzN68zaGJS3JZ2UJNx9UTz/qt+TqPAaF9+ngUEhF1iuZCBqoxW2tSg6splHlzXtW9Xk4xBmx5IbssoZWf57iw==",
-      "dependencies": {
-        "@cospired/i18n-iso-languages": "2.2.0",
-        "@formatjs/intl-pluralrules": "4.3.3",
-        "@formatjs/intl-relativetimeformat": "10.0.1",
-        "axios": "0.27.2",
-        "axios-cache-interceptor": "0.10.7",
-        "form-urlencoded": "4.1.4",
-        "glob": "7.2.3",
-        "history": "4.10.1",
-        "i18n-iso-countries": "4.3.1",
-        "jwt-decode": "3.1.2",
-        "localforage": "1.10.0",
-        "localforage-memoryStorageDriver": "0.9.2",
-        "lodash.camelcase": "4.3.0",
-        "lodash.memoize": "4.1.2",
-        "lodash.merge": "4.6.2",
-        "lodash.snakecase": "4.1.1",
-        "pubsub-js": "1.9.4",
-        "react-intl": "^5.25.0",
-        "universal-cookie": "4.0.4"
-      },
-      "bin": {
-        "intl-imports.js": "i18n/scripts/intl-imports.js",
-        "transifex-utils.js": "i18n/scripts/transifex-utils.js"
-      },
-      "peerDependencies": {
-        "@edx/paragon": ">= 10.0.0 < 21.0.0",
-        "prop-types": "^15.7.2",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0",
-        "react-redux": "^7.1.1",
-        "react-router-dom": "^5.0.1",
-        "redux": "^4.0.4"
       }
     },
     "node_modules/@edx/frontend-component-footer/node_modules/@fortawesome/fontawesome-common-types": {
@@ -3184,11 +3145,12 @@
       }
     },
     "node_modules/@edx/frontend-component-header": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.6.5.tgz",
-      "integrity": "sha512-7B0AxNDm/U/ooYXNfguhzl8W4GhCUFLwJ//Aq9GLMumZcmvS33O+JtOw5isrV5VkdFN/OODnzb0AX6mTexi7Cg==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.7.3.tgz",
+      "integrity": "sha512-FbjQ3agHXkZmNzV8cpQg+F3ttvlhqGDnMrxOFuQhb9eFJK48q+L0PhfhCjKx+tPi3aeovtcc0vjG/dzGZs5+Gw==",
       "dependencies": {
-        "@edx/paragon": "20.28.5",
+        "@edx/frontend-platform": "^4.1.0",
+        "@edx/paragon": "20.30.1",
         "@fortawesome/fontawesome-svg-core": "6.3.0",
         "@fortawesome/free-brands-svg-icons": "6.3.0",
         "@fortawesome/free-regular-svg-icons": "6.3.0",
@@ -3199,10 +3161,9 @@
         "react-transition-group": "4.4.5"
       },
       "peerDependencies": {
-        "@edx/frontend-platform": "^2.0.0 || ^3.0.0",
         "prop-types": "^15.5.10",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
     "node_modules/@edx/frontend-component-header/node_modules/@fortawesome/fontawesome-common-types": {
@@ -3263,9 +3224,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-3.3.1.tgz",
-      "integrity": "sha512-EF2a5Ovzhu5URo7ER6Mc/K+l02UGuXpd2bQw+dW/xGe/hlv+1CDnrzDTqM8QEk+suZyQfI9U0fnsqwcwr0a2SA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.1.0.tgz",
+      "integrity": "sha512-7RzN68zaGJS3JZ2UJNx9UTz/qt+TqPAaF9+ngUEhF1iuZCBqoxW2tSg6splHlzXtW9Xk4xBmx5IbssoZWf57iw==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -3288,13 +3249,14 @@
         "universal-cookie": "4.0.4"
       },
       "bin": {
+        "intl-imports.js": "i18n/scripts/intl-imports.js",
         "transifex-utils.js": "i18n/scripts/transifex-utils.js"
       },
       "peerDependencies": {
         "@edx/paragon": ">= 10.0.0 < 21.0.0",
         "prop-types": "^15.7.2",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
         "react-redux": "^7.1.1",
         "react-router-dom": "^5.0.1",
         "redux": "^4.0.4"
@@ -3310,9 +3272,9 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "20.28.5",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.28.5.tgz",
-      "integrity": "sha512-6cW9Pl1hojOGfGatLjeojzr0qNfil6rlwB3APKZlgomscDxVzYbaQYyZNOx/k2dFaO8EKCpiApXhHW+WihQipg==",
+      "version": "20.30.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.30.1.tgz",
+      "integrity": "sha512-v3Ek8deZWqVKi3IWP08Mj4egrvbmbqQEyRA6+qazHZdgHJA4qOP1SST42UKd9XxPeRbLWUgaJWd0iBAOAna/gw==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -3327,6 +3289,7 @@
         "mailto-link": "^2.0.0",
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.5",
+        "react-colorful": "^5.6.1",
         "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
         "react-loading-skeleton": "^3.1.0",
@@ -20015,6 +19978,15 @@
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -26576,11 +26548,11 @@
       }
     },
     "@edx/frontend-component-footer": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.2.tgz",
-      "integrity": "sha512-joyygHAE8kuG50FIjiY8obEG0ARVAVRrJXOiOCHWGfu2Mie02/Rv0lFpwTdeBC0AHS6rnegXSdzhjuVgigyx1A==",
+      "version": "11.7.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-footer/-/frontend-component-footer-11.7.3.tgz",
+      "integrity": "sha512-CSLofrLoCglJTSk9SxdTAF/5nqjlJDcisgzSFj57+ecMcbqCUyZlE7yFxKly3NGMnNw+lXIYr9hps7gpOQMnHg==",
       "requires": {
-        "@edx/frontend-platform": "^4.0.1",
+        "@edx/frontend-platform": "^4.1.0",
         "@fortawesome/fontawesome-svg-core": "6.4.0",
         "@fortawesome/free-brands-svg-icons": "6.4.0",
         "@fortawesome/free-regular-svg-icons": "6.4.0",
@@ -26588,32 +26560,6 @@
         "@fortawesome/react-fontawesome": "0.2.0"
       },
       "dependencies": {
-        "@edx/frontend-platform": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.1.0.tgz",
-          "integrity": "sha512-7RzN68zaGJS3JZ2UJNx9UTz/qt+TqPAaF9+ngUEhF1iuZCBqoxW2tSg6splHlzXtW9Xk4xBmx5IbssoZWf57iw==",
-          "requires": {
-            "@cospired/i18n-iso-languages": "2.2.0",
-            "@formatjs/intl-pluralrules": "4.3.3",
-            "@formatjs/intl-relativetimeformat": "10.0.1",
-            "axios": "0.27.2",
-            "axios-cache-interceptor": "0.10.7",
-            "form-urlencoded": "4.1.4",
-            "glob": "7.2.3",
-            "history": "4.10.1",
-            "i18n-iso-countries": "4.3.1",
-            "jwt-decode": "3.1.2",
-            "localforage": "1.10.0",
-            "localforage-memoryStorageDriver": "0.9.2",
-            "lodash.camelcase": "4.3.0",
-            "lodash.memoize": "4.1.2",
-            "lodash.merge": "4.6.2",
-            "lodash.snakecase": "4.1.1",
-            "pubsub-js": "1.9.4",
-            "react-intl": "^5.25.0",
-            "universal-cookie": "4.0.4"
-          }
-        },
         "@fortawesome/fontawesome-common-types": {
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
@@ -26654,11 +26600,12 @@
       }
     },
     "@edx/frontend-component-header": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.6.5.tgz",
-      "integrity": "sha512-7B0AxNDm/U/ooYXNfguhzl8W4GhCUFLwJ//Aq9GLMumZcmvS33O+JtOw5isrV5VkdFN/OODnzb0AX6mTexi7Cg==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-3.7.3.tgz",
+      "integrity": "sha512-FbjQ3agHXkZmNzV8cpQg+F3ttvlhqGDnMrxOFuQhb9eFJK48q+L0PhfhCjKx+tPi3aeovtcc0vjG/dzGZs5+Gw==",
       "requires": {
-        "@edx/paragon": "20.28.5",
+        "@edx/frontend-platform": "^4.1.0",
+        "@edx/paragon": "20.30.1",
         "@fortawesome/fontawesome-svg-core": "6.3.0",
         "@fortawesome/free-brands-svg-icons": "6.3.0",
         "@fortawesome/free-regular-svg-icons": "6.3.0",
@@ -26709,9 +26656,9 @@
       }
     },
     "@edx/frontend-platform": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-3.3.1.tgz",
-      "integrity": "sha512-EF2a5Ovzhu5URo7ER6Mc/K+l02UGuXpd2bQw+dW/xGe/hlv+1CDnrzDTqM8QEk+suZyQfI9U0fnsqwcwr0a2SA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.1.0.tgz",
+      "integrity": "sha512-7RzN68zaGJS3JZ2UJNx9UTz/qt+TqPAaF9+ngUEhF1iuZCBqoxW2tSg6splHlzXtW9Xk4xBmx5IbssoZWf57iw==",
       "requires": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -26744,9 +26691,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "20.28.5",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.28.5.tgz",
-      "integrity": "sha512-6cW9Pl1hojOGfGatLjeojzr0qNfil6rlwB3APKZlgomscDxVzYbaQYyZNOx/k2dFaO8EKCpiApXhHW+WihQipg==",
+      "version": "20.30.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.30.1.tgz",
+      "integrity": "sha512-v3Ek8deZWqVKi3IWP08Mj4egrvbmbqQEyRA6+qazHZdgHJA4qOP1SST42UKd9XxPeRbLWUgaJWd0iBAOAna/gw==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -26761,6 +26708,7 @@
         "mailto-link": "^2.0.0",
         "prop-types": "^15.8.1",
         "react-bootstrap": "^1.6.5",
+        "react-colorful": "^5.6.1",
         "react-dropzone": "^14.2.1",
         "react-focus-on": "^3.5.4",
         "react-loading-skeleton": "^3.1.0",
@@ -39511,6 +39459,12 @@
       "requires": {
         "@babel/runtime": "^7.12.13"
       }
+    },
+    "react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "12.0.1",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
-    "@edx/frontend-component-footer": "11.7.2",
-    "@edx/frontend-component-header": "3.6.5",
-    "@edx/frontend-platform": "3.3.1",
+    "@edx/frontend-component-footer": "11.7.3",
+    "@edx/frontend-component-header": "3.7.3",
+    "@edx/frontend-platform": "4.1.0",
     "@edx/paragon": "^20.20.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "5.15.4",

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,3 +1,6 @@
+import { messages as headerMessages } from '@edx/frontend-component-header';
+import { messages as footerMessages } from '@edx/frontend-component-footer';
+
 import arMessages from './messages/ar.json';
 import caMessages from './messages/ca.json';
 // no need to import en messages-- they are in the defaultMessage field
@@ -13,7 +16,7 @@ import ruMessages from './messages/ru.json';
 import thMessages from './messages/th.json';
 import ukMessages from './messages/uk.json';
 
-const messages = {
+const appMessages = {
   ar: arMessages,
   'es-419': es419Messages,
   fr: frMessages,
@@ -29,4 +32,8 @@ const messages = {
   uk: ukMessages,
 };
 
-export default messages;
+export default [
+  headerMessages,
+  footerMessages,
+  appMessages,
+];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,10 +7,9 @@ import {
 import { AppProvider, ErrorPage } from '@edx/frontend-platform/react';
 import ReactDOM from 'react-dom';
 
-import Header, { messages as headerMessages } from '@edx/frontend-component-header';
-import Footer, { messages as footerMessages } from '@edx/frontend-component-footer';
-
-import appMessages from './i18n';
+import Header from '@edx/frontend-component-header';
+import Footer from '@edx/frontend-component-footer';
+import messages from './i18n';
 import ExamplePage from './example/ExamplePage';
 
 import './index.scss';
@@ -31,9 +30,5 @@ subscribe(APP_INIT_ERROR, (error) => {
 });
 
 initialize({
-  messages: [
-    appMessages,
-    headerMessages,
-    footerMessages,
-  ],
+  messages,
 });


### PR DESCRIPTION
## Changes
 - Bump frontend-platform to bring intl-imports.js script
 - Move all i18n imports into `src/i18n/index.js` so intl-imports.js can override it with latest translations
 - Add `atlas` into `make pull_translations` when `OPENEDX_ATLAS_PULL` environment variable is set.

## Related PRs

 - This pull request creates conflicts with https://github.com/openedx/frontend-template-application/pull/556, but it's rather easy conflicts to resolve in `package.json`

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes


**For Micro-frontends and their template:**

 - Legacy hardcoded translations are kept into the repo.
 - Consolidate all i18n imports into `src/i18n/index.js`
 - Add `atlas` integration in `make pull_translations` but only if `OPENEDX_ATLAS_PULL` is set
 - Bump frontend-platform and use `intl-imports.js` to generate up to date import files



