### PR TITLE
Update renovate.json

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,5 +72,5 @@ Please see `edx/frontend-platform's i18n module <https://edx.github.io/frontend-
    :target: https://travis-ci.com/edx/frontend-template-application
 .. |Codecov| image:: https://codecov.io/gh/edx/frontend-template-application/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/edx/frontend-template-application
-.. |license| image:: https://img.shields.io/npm/l/@edx/frontend-template-application.svg
-   :target: @edx/frontend-template-application
+.. |license| image:: https://img.shields.io/github/license/openedx/frontend-template-application.svg
+   :target: https://github.com/openedx/frontend-template-application/blob/main/LICENSE

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       "automerge": true
     },
     {
-      "matchPackagePatterns": ["@edx"],
+      "matchPackagePatterns": ["@edx", "@openedx"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }


### PR DESCRIPTION
We'll eventually want to be publishing the packages under the `openedx` username instead of the `edx` one.  Update the matching config so that renovate will continue to work when we do that.