### PR TITLE
docs: security reports should go to security@openedx.org

### DIFF
--- a/README-template-frontend-app.rst
+++ b/README-template-frontend-app.rst
@@ -256,4 +256,4 @@ file in this repo.
 Reporting Security Issues
 =========================
 
-Please do not report security issues in public.  Email security@axim.org instead.
+Please do not report security issues in public.  Email security@openedx.org instead.

--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,7 @@ file in this repo.
 Reporting Security Issues
 *************************
 
-Please do not report security issues in public, and email security@axim.org instead.
+Please do not report security issues in public, and email security@openedx.org instead.
 
 .. |license-badge| image:: https://img.shields.io/github/license/openedx/frontend-template-application.svg
     :target: https://github.com/openedx/frontend-template-application/blob/main/LICENSE


### PR DESCRIPTION
My understanding is that security reports should go to security@openedx.org: Project-related communications should use the project email domain, not the organization domain.

@feanil True?