### PR TITLE
feat: include paragon in atlas pull as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,10 @@ pull_translations:
 	mkdir src/i18n/messages
 	cd src/i18n/messages \
 	   && atlas pull --filter=$(transifex_langs) \
+	            translations/paragon/src/i18n/messages:paragon \
 	            translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
 	            translations/frontend-component-header/src/i18n/messages:frontend-component-header \
 	            translations/frontend-template-application/src/i18n/messages:frontend-template-application
 
-	$(intl_imports) frontend-component-header frontend-component-footer frontend-template-application
+	$(intl_imports) paragon frontend-component-header frontend-component-footer frontend-template-application
 endif


### PR DESCRIPTION
This is a follow up to https://github.com/openedx/frontend-template-application/pull/612 . #612 should have included the changes but apparently OEP-58 needs more publicity.

Testing
--------

I've ran the following:

```
$ OPENEDX_ATLAS_PULL=yes make pull_translations
$ cat src/i18n/index.js
```

Generates the following code, which seems to be good:

```js
// This file is generated by the openedx/frontend-platform's "intl-import.js" script.
//
// Refer to the i18n documents in https://docs.openedx.org/en/latest/developers/references/i18n.html to update
// the file and use the Micro-frontend i18n pattern in new repositories.
//

import messagesFromParagon from './messages/paragon';
import messagesFromFrontendComponentHeader from './messages/frontend-component-header';
import messagesFromFrontendComponentFooter from './messages/frontend-component-footer';
// Skipped import due to missing 'frontend-template-application/index.js' likely due to empty translations..

export default [
  messagesFromParagon,
  messagesFromFrontendComponentHeader,
  messagesFromFrontendComponentFooter,
];
```

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes:

**For Micro-frontends:**

 - Legacy hardcoded translations are kept into the repo.
 - Consolidate all i18n imports into `src/i18n/index.js`
 - Add `atlas` integration in `make pull_translations` but only if `OPENEDX_ATLAS_PULL` is set
 - Bump frontend-platform and use `intl-imports.js` to generate up to date import files
 - If translations is missing, they're added according to the latest Micro-frontend i18n pattern in par with https://github.com/openedx/frontend-template-application/


