### PR TITLE
test: fix lockfile workflow filename

### DIFF
--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   version-check:
-    uses: openedx/.github/.github/workflows/lockfile-check-v3.yml@master
+    uses: openedx/.github/.github/workflows/lockfileversion-check-v3.yml@master


### PR DESCRIPTION
This bug was introduced in the recent [Node 20 Upgrade PR](https://github.com/openedx/frontend-template-application/pull/744).  It should refer to this:

https://github.com/openedx/.github/blob/master/.github/workflows/lockfileversion-check-v3.yml