### PR TITLE
Browser header showing null

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en-us">
   <head>
-      <title>Application Template | <%= process.env.SITE_NAME %></title>
+      <title>Application Template <%= (process.env.SITE_NAME && process.env.SITE_NAME != 'null') ? '| ' + process.env.SITE_NAME  : '' %></title>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />


### PR DESCRIPTION
The purpose of this PR is that whenever a new frontend app is created from this template, it shouldn't show `App Template | null` in case `process.env.SITE_NAME` is null. This kind of issue arose in [`frontend-app-auth` ](https://github.com/openedx/frontend-app-authn/pull/1185)and resolved there resulting in similar change requirement in this repository.

For detailed context, see this [#1158](https://github.com/openedx/frontend-app-authn/issues/1158)