### PR TITLE
fix: add openedx-atlas as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@edx/frontend-component-footer": "^14.6.0",
         "@edx/frontend-component-header": "^6.4.0",
         "@edx/frontend-platform": "^8.0.0",
+        "@edx/openedx-atlas": "^0.6.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
         "@fortawesome/free-regular-svg-icons": "5.15.4",
@@ -2334,6 +2335,15 @@
       "integrity": "sha512-OrlvtdsPcWuOm6NBWfUxFE06qdPiu2bf9nU4I9t8Lu7WW6NsosAB5hxm5U+MBMZP2AuVl3FAt0k0lZsu3+ri8Q==",
       "dependencies": {
         "@newrelic/publish-sourcemap": "^5.0.1"
+      }
+    },
+    "node_modules/@edx/openedx-atlas": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@edx/openedx-atlas/-/openedx-atlas-0.6.2.tgz",
+      "integrity": "sha512-28Q8vzJDMS4wUxdkbIUBQpzWJ3HTdMaGlaEhFjrVGfuZkh++1AG6Tn/7FMD88cegalYAkphu530VQCHEkMZQhw==",
+      "license": "AGPL-3.0",
+      "bin": {
+        "atlas": "atlas"
       }
     },
     "node_modules/@edx/reactifex": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@edx/frontend-component-header": "^6.4.0",
     "@edx/frontend-component-footer": "^14.6.0",
     "@edx/frontend-platform": "^8.0.0",
+    "@edx/openedx-atlas": "^0.6.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "5.15.4",
     "@fortawesome/free-regular-svg-icons": "5.15.4",


### PR DESCRIPTION
When creating a new MFE with tutor and mounting it for development, the image build fails because atlas does not exist during the pull_translations step.

Atlas has been a necessary part of the image build process since #576 to pull translations and we now add it as a dependency from start so that the build step does not fail.