### PR TITLE
chore: update codecov/codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: i18n_extract
       run: npm run i18n_extract
     - name: Coverage
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true


### PR DESCRIPTION
The pinned `v5.5.4` codecov-action uploader now fails during setup ("required dependencies are missing"). Because the Coverage step sets `fail_ci_if_error: true`, this fails the whole CI job — which blocks unrelated Dependabot action bumps (#947, #959) from going green.

Bump to `v7.0.0` (pinned SHA `fb8b3582…`), matching the version now used across the org. Once merged, the blocked Dependabot PRs can rebase and pass.