### PR TITLE
feat!: upgrade to frontend-base 2.0

### DIFF
--- a/README-template-frontend-app.rst
+++ b/README-template-frontend-app.rst
@@ -91,6 +91,33 @@ bind-mount it as an npm workspace:
 Configuration
 -------------
 
+``getAppConfig`` resolves three sources, in order of increasing
+precedence: the app's bundled ``defaultConfig``, the site's
+``commonAppConfig``, and the app's ``config``.  The first is yours, set
+in ``src/app.ts`` at build time.  The other two are the operator's, the
+second applying to every app on the site and the third to this app
+alone; in edx-platform they arrive as ``MFE_CONFIG`` and
+``MFE_CONFIG_OVERRIDES['<app>']``.
+
+Put shipped defaults in ``defaultConfig`` and leave ``config`` to the
+operator, because every key an app declares in ``config`` is a key the
+operator's site-wide configuration can never supply.  Not every default
+belongs there: some are better handled at the point of use.  Bundle the
+ones that are product decisions the app owns and an operator should be
+able to override, such as a default logo.  See `ADR 0017`_.
+
+Because a bundled default lives in its own field, overriding one value
+no longer means spreading the app's existing config back in::
+
+    {
+      ...myApp,
+      config: {
+        SOME_KEY: true,
+      },
+    }
+
+.. _ADR 0017: https://github.com/openedx/frontend-base/blob/main/docs/decisions/0017-bundled-app-config-defaults.rst
+
 .. note::
 
    [TODO]
@@ -98,8 +125,9 @@ Configuration
    Explicitly list anything that this app requires to function correctly.
    This includes:
 
-   * A list of required and optional ``site.config.*.tsx`` fields and
-     per-app ``config`` values, and how each affects behaviour
+   * A list of required and optional ``site.config.*.tsx`` fields, the
+     defaults the app bundles in ``defaultConfig``, and the ``config``
+     values an operator can set, and how each affects behaviour
 
    * A list of edx-platform `feature and waffle flags`_ that are either
      required to enable use of this app, or affect the behaviour of the

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "turbo": "^2.9.2"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-base": "^2.0.0-alpha || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -2631,115 +2631,15 @@
       }
     },
     "node_modules/@formatjs/intl": {
-      "version": "2.10.15",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.15.tgz",
-      "integrity": "sha512-i6+xVqT+6KCz7nBfk4ybMXmbKO36tKvbMKtgFz9KV+8idYFyFbfwKooYk8kGjyA5+T5f1kEPQM5IDLXucTAQ9g==",
+      "version": "4.1.19",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.19.tgz",
+      "integrity": "sha512-bZMROATl+rzfL8wsDZ53i8XWHx5e6rVr8QlGT5GDvHImEUro4WE9pxUd2dobzmI3CtD+zkt/wkEdqcb+3CK8Fg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "@formatjs/intl-displaynames": "6.8.5",
-        "@formatjs/intl-listformat": "7.7.5",
-        "intl-messageformat": "10.7.7",
-        "tslib": "2"
-      },
-      "peerDependencies": {
-        "typescript": "^4.7 || 5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.8.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.8.5.tgz",
-      "integrity": "sha512-85b+GdAKCsleS6cqVxf/Aw/uBd+20EM0wDpgaxzHo3RIR3bxF4xCJqH/Grbzx8CXurTgDDZHPdPdwJC+May41w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.7.5.tgz",
-      "integrity": "sha512-Wzes10SMNeYgnxYiKsda4rnHP3Q3II4XT2tZyOgnH5fWuHDtIkceuWlRQNsvrI3uiwP4hLqp2XdQTCsfkhXulg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17",
+        "intl-messageformat": "11.2.14"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
@@ -2752,60 +2652,29 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
     "node_modules/@formatjs/intl/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
+      "peer": true
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
-      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/@formatjs/intl/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
-      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
+      "peer": true
     },
     "node_modules/@formatjs/ts-transformer": {
       "version": "3.14.2",
@@ -4484,9 +4353,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.1.tgz",
-      "integrity": "sha512-Xi5D2SqXxTgbGzZRM3F0oSCJkR+6KWnGULAmfw3TQOkmJ43jDIZ0BZ1XrJySScaSXkibG4OZCtcHSjV4IHgm/g==",
+      "version": "2.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-2.0.0-alpha.5.tgz",
+      "integrity": "sha512-A+HKgSAmtoaTa535/0+Opigco2XvEKq9sIZ6SvXyr726paFbPF8Zc/Pe1jepr/Q828vbVHa+wlAnkjl3KHCIOw==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {
@@ -4547,7 +4416,7 @@
         "prop-types": "^15.8.1",
         "react-dev-utils": "12.0.1",
         "react-focus-on": "^3.10.2",
-        "react-intl": "^6.6.6",
+        "react-intl": "^10.1.20",
         "react-refresh": "0.18.0",
         "react-refresh-typescript": "^2.0.9",
         "react-responsive": "^10.0.0",
@@ -4576,7 +4445,7 @@
         "openedx": "dist/tools/cli/openedx.js"
       },
       "peerDependencies": {
-        "@openedx/paragon": "^23.20.0",
+        "@openedx/paragon": "^23.23.0",
         "@tanstack/react-query": "^5.81.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4585,9 +4454,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "23.21.2",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.21.2.tgz",
-      "integrity": "sha512-CBRAIWIk93Dp8U8WFk56pnu8GLoJCPGKVY/s0P3aq+bYeM4+YnN303Ex9jYlhmZztjRPW4P5Cx+xuXXuBKkfoA==",
+      "version": "23.23.0",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.23.0.tgz",
+      "integrity": "sha512-dr4zDytE7YC/Hk3sIl3MBgLyeIJBZpPp0tI2x+SQ1d/tJXhyJk4pDOfG8bFbGHt4jaM/cwjwX25jaTUV1jszIg==",
       "license": "Apache-2.0",
       "peer": true,
       "workspaces": [
@@ -4603,7 +4472,6 @@
         "axios": "^1.0.0",
         "bootstrap": "^4.6.2",
         "chalk": "^4.1.2",
-        "child_process": "^1.0.2",
         "chroma-js": "^3.0.0",
         "classnames": "^2.3.1",
         "cli-progress": "^3.12.0",
@@ -4649,7 +4517,7 @@
       "peerDependencies": {
         "react": "^16.8.6 || ^17 || ^18",
         "react-dom": "^16.8.6 || ^17 || ^18",
-        "react-intl": "^5.25.1 || ^6.4.0"
+        "react-intl": "^5.25.1 || ^6.4.0 || ^10.1.20"
       }
     },
     "node_modules/@openedx/paragon/node_modules/glob": {
@@ -5836,19 +5704,6 @@
       "peer": true,
       "dependencies": {
         "@types/tinycolor2": "*"
-      }
-    },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -8009,13 +7864,6 @@
       "engines": {
         "node": ">=22.0.0"
       }
-    },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g==",
-      "license": "ISC",
-      "peer": true
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -11553,23 +11401,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -12195,72 +12026,39 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.7.7",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.7.tgz",
-      "integrity": "sha512-F134jIoeYMro/3I0h08D0Yt4N9o9pjddU/4IIxMMURqbAtI2wu70X8hvG1V48W49zXHXv3RKSF/po+0fDfsGjA==",
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.14.tgz",
+      "integrity": "sha512-9f2VD1HFuxUvMw0RxsaP8WmMns6JRTnsNB/zghTFrp11ZktiXWwVDeZBPQchBKEmo+Gx/ZhxI7Qht7YglFD4PA==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.17"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
+      "peer": true
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
-      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/intl-messageformat/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
-      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
+      "peer": true
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -17720,87 +17518,37 @@
       }
     },
     "node_modules/react-intl": {
-      "version": "6.8.9",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.8.9.tgz",
-      "integrity": "sha512-TUfj5E7lyUDvz/GtovC9OMh441kBr08rtIbgh3p0R8iF3hVY+V2W9Am7rb8BpJ/29BH1utJOqOOhmvEVh3GfZg==",
+      "version": "10.1.24",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-10.1.24.tgz",
+      "integrity": "sha512-8hiXRnnmOMEPvE5xb1T1Ce1AsmuSWX2voosCsmiyOEGEq83d1mbHy2M1DeoGKt4yF5oPPkzp+aUwSOtf+NYKPA==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-messageformat-parser": "2.9.4",
-        "@formatjs/intl": "2.10.15",
-        "@formatjs/intl-displaynames": "6.8.5",
-        "@formatjs/intl-listformat": "7.7.5",
-        "@types/hoist-non-react-statics": "3",
-        "@types/react": "16 || 17 || 18",
-        "hoist-non-react-statics": "3",
-        "intl-messageformat": "10.7.7",
-        "tslib": "2"
+        "@formatjs/icu-messageformat-parser": "3.5.17",
+        "@formatjs/intl": "4.1.19",
+        "intl-messageformat": "11.2.14"
       },
       "peerDependencies": {
-        "react": "^16.6.0 || 17 || 18",
-        "typescript": "^4.7 || 5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
-      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/fast-memoize": "2.2.3",
-        "@formatjs/intl-localematcher": "0.5.8",
-        "tslib": "2"
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
-      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
-      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.17.tgz",
+      "integrity": "sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "@formatjs/icu-skeleton-parser": "1.8.8",
-        "tslib": "2"
+        "@formatjs/icu-skeleton-parser": "2.1.11"
       }
     },
     "node_modules/react-intl/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
-      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.4",
-        "tslib": "2"
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
-      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "2"
-      }
+      "peer": true
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "turbo": "^2.9.2"
   },
   "peerDependencies": {
-    "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
+    "@openedx/frontend-base": "^2.0.0-alpha || 0.0.0-dev",
     "@openedx/paragon": "^23",
     "@tanstack/react-query": "^5",
     "react": "^18",

--- a/site.config.test.tsx
+++ b/site.config.test.tsx
@@ -11,7 +11,6 @@ const siteConfig: SiteConfig = {
   environment: EnvironmentTypes?.TEST ?? 'test',
   apps: [{
     appId: 'org.openedx.frontend.app.template',
-    config: {},
   }],
 };
 


### PR DESCRIPTION
### Description

Takes the `@openedx/frontend-base` peer dependency to `^2.0.0-alpha || 0.0.0-dev`, part of openedx/frontend-base#299. The range stays generic rather than naming a specific alpha, since a template should not pin copies of itself to whichever prerelease happened to be current. Nothing else was required, as the issue predicted: the template imports nothing from `react-intl`, declares no TypeScript type members for the new semicolon rule to catch, and bundles no config for `App.defaultConfig` to hold. Two things came along anyway. The empty `config` on the test site's app entry goes, since after ADR 0017 `config` is the operator's field. And the lockfile takes `@openedx/paragon` to 23.23.0, the floor frontend-base 2.0 requires, without which `npm ci` fails the peer check.

The second commit is the part specific to this repository being a template. `README-template-frontend-app.rst` is what every new App Repository starts from, and its Configuration section spoke only of per-app `config`. It now explains how `getAppConfig` resolves bundled `defaultConfig` below `commonAppConfig` below `config`, and which field a shipped default belongs in.

Closes #1033

### LLM usage notice

Built with assistance from Claude.
