### PR TITLE
build: restore build:packages on turbo 2.10.1+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TURBO = TURBO_TELEMETRY_DISABLED=1 turbo --dangerously-disable-package-manager-check
+TURBO = TURBO_TELEMETRY_DISABLED=1 turbo
 i18n = ./src/i18n
 
 precommit:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5427,9 +5427,9 @@
       }
     },
     "node_modules/@turbo/darwin-64": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.6.tgz",
-      "integrity": "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.12.tgz",
+      "integrity": "sha512-9nKgKoF6ZOUsM+or0OtNf+TTJSfGvDNP7ZFv/ZGWVwOSCkumyctQiTeHwB4UNljHTnC41AqylgbunLDHoccNrA==",
       "cpu": [
         "x64"
       ],
@@ -5441,9 +5441,9 @@
       ]
     },
     "node_modules/@turbo/darwin-arm64": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.6.tgz",
-      "integrity": "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.10.12.tgz",
+      "integrity": "sha512-H4Elb1jqTZVeIC9bbcNwjSzemZ6RegoTOVHeuV5Osirt2Z8UguTyisMEkvZjPVZgMeN9J4ERZBFad40tFnkb7w==",
       "cpu": [
         "arm64"
       ],
@@ -5455,9 +5455,9 @@
       ]
     },
     "node_modules/@turbo/linux-64": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.6.tgz",
-      "integrity": "sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.10.12.tgz",
+      "integrity": "sha512-lr7KIotukvjZwEXiFSYAeOH3BWzjFVBbSzTbv0fuGFsNukYyH0+g1hB5ecqnJkgkYU+KHEMG1edOhnjiKON1wQ==",
       "cpu": [
         "x64"
       ],
@@ -5465,13 +5465,14 @@
       "license": "MIT",
       "optional": true,
       "os": [
+        "android",
         "linux"
       ]
     },
     "node_modules/@turbo/linux-arm64": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.6.tgz",
-      "integrity": "sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.10.12.tgz",
+      "integrity": "sha512-f0pZDTtvzB5SuNwuXBaKbZHUCMCukgc8nMlHEuvLmj91Fzec+MEbr3cAvGNor5htEDqZnO6Lxt9N/GPI/77oGA==",
       "cpu": [
         "arm64"
       ],
@@ -5479,13 +5480,14 @@
       "license": "MIT",
       "optional": true,
       "os": [
+        "android",
         "linux"
       ]
     },
     "node_modules/@turbo/windows-64": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.6.tgz",
-      "integrity": "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.10.12.tgz",
+      "integrity": "sha512-SDOueJRjS/QcykWf2KCRtTLmIl5YMKsLbXkXQGhDwcTXvKXZiS5ih5lBl/gkwZIpYFjqA/rAlfMzlAFcVHNe0g==",
       "cpu": [
         "x64"
       ],
@@ -5497,9 +5499,9 @@
       ]
     },
     "node_modules/@turbo/windows-arm64": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.6.tgz",
-      "integrity": "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.10.12.tgz",
+      "integrity": "sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA==",
       "cpu": [
         "arm64"
       ],
@@ -20795,21 +20797,21 @@
       "peer": true
     },
     "node_modules/turbo": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.6.tgz",
-      "integrity": "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.12.tgz",
+      "integrity": "sha512-AswgMPnpOoaVZHrrSBejETzEbuIA69OVGwfkHwfrY0A23VjWXBANzgq9+OymWOHAIArB7D1+1z498WY8fGg1Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "@turbo/darwin-64": "2.9.6",
-        "@turbo/darwin-arm64": "2.9.6",
-        "@turbo/linux-64": "2.9.6",
-        "@turbo/linux-arm64": "2.9.6",
-        "@turbo/windows-64": "2.9.6",
-        "@turbo/windows-arm64": "2.9.6"
+        "@turbo/darwin-64": "2.10.12",
+        "@turbo/darwin-arm64": "2.10.12",
+        "@turbo/linux-64": "2.10.12",
+        "@turbo/linux-arm64": "2.10.12",
+        "@turbo/windows-64": "2.10.12",
+        "@turbo/windows-arm64": "2.10.12"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openedx/frontend-template-application",
   "version": "0.0.0-dev",
+  "packageManager": "npm@11.12.1",
   "description": "Frontend application template",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

`make build-packages` fails on turbo 2.10.1 and later with `package_task_in_single_package_mode`, rejecting the `//#dev:site` root task. turbo 2.10.1 reworked package manager detection, and with no `packageManager` field it falls back to single-package mode, where `//#` root tasks are invalid.

Declaring `packageManager` fixes it. The `--dangerously-disable-package-manager-check` flag was compensating for the missing field and is what now triggers the fallback, so it comes out too. The lockfile bump takes turbo to an affected version, where this is verified.

Part of openedx/frontend-base#312.

### LLM usage notice

Built with assistance from Claude.
